### PR TITLE
APIM 13058 doc gen multi module

### DIFF
--- a/pkg/core/bootstrap/load.go
+++ b/pkg/core/bootstrap/load.go
@@ -26,8 +26,9 @@ const RootDirDataKey = "rootDir"
 const ConfigResolver = "configResolver"
 
 type data struct {
-	Filename   string `yaml:"file"`
-	ExportedAs string `yaml:"exportedAs"`
+	Filename     string `yaml:"file"`
+	FallbackFile string `yaml:"fallbackFile"`
+	ExportedAs   string `yaml:"exportedAs"`
 }
 
 type fileContent struct {
@@ -62,7 +63,11 @@ func Load(rootDir string) error {
 	reg.data[ConfigResolver] = bootstrap.ChuckConfigResolver
 
 	for _, data := range bootstrap.Data {
-		_, err := load(data.Filename, data.ExportedAs)
+		file := data.Filename
+		if _, err := os.Stat(file); err != nil && data.FallbackFile != "" {
+			file = data.FallbackFile
+		}
+		_, err := load(file, data.ExportedAs)
 		if err != nil {
 			return err
 		}

--- a/tests/core/bootstrap/load_test.go
+++ b/tests/core/bootstrap/load_test.go
@@ -15,7 +15,11 @@
 package bootstrap
 
 import (
+	"os"
+
 	"github.com/gravitee-io/gravitee-doc-gen/pkg/core/bootstrap"
+	bplugin "github.com/gravitee-io/gravitee-doc-gen/pkg/extenstions/bootstrap/filehandlers"
+	"github.com/gravitee-io/gravitee-doc-gen/pkg/extenstions/bootstrap/plugin"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 )
@@ -25,6 +29,34 @@ var _ = Describe("cloud object context methods", func() {
 		It("trigger no error", func() {
 			Expect(bootstrap.Load("empty")).To(Succeed())
 			Expect(bootstrap.GetExported()).To(HaveKeyWithValue("RootDir", "empty"))
+		})
+	})
+
+	When("plugin.properties is missing but .docgen/plugin.properties fallback exists", func() {
+		var origDir string
+
+		BeforeEach(func() {
+			var err error
+			origDir, err = os.Getwd()
+			Expect(err).NotTo(HaveOccurred())
+			Expect(os.Chdir("with-docgen-plugin")).To(Succeed())
+
+			bootstrap.Register(bplugin.PropertiesFileHandler, bplugin.PropertiesExt)
+			bootstrap.Register(bplugin.YamlFileHandler, bplugin.YamlExt, bplugin.YmlExt)
+			bootstrap.RegisterPostProcessor("plugin", plugin.PostProcessor)
+		})
+
+		AfterEach(func() {
+			Expect(os.Chdir(origDir)).To(Succeed())
+		})
+
+		It("falls back to .docgen/plugin.properties and loads plugin metadata", func() {
+			Expect(bootstrap.Load(".")).To(Succeed())
+			p, ok := bootstrap.GetData("plugin").(plugin.Plugin)
+			Expect(ok).To(BeTrue())
+			Expect(p.ID).To(Equal("test-plugin"))
+			Expect(p.Title).To(Equal("Test Plugin"))
+			Expect(p.Type).To(Equal("policy"))
 		})
 	})
 })

--- a/tests/core/bootstrap/with-docgen-plugin/.docgen/plugin.properties
+++ b/tests/core/bootstrap/with-docgen-plugin/.docgen/plugin.properties
@@ -1,0 +1,17 @@
+# Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+id=test-plugin
+type=policy
+name=Test Plugin

--- a/tests/core/bootstrap/with-docgen-plugin/bootstrap.yaml
+++ b/tests/core/bootstrap/with-docgen-plugin/bootstrap.yaml
@@ -1,0 +1,19 @@
+# Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+data:
+  - file: src/main/resources/plugin.properties
+    fallbackFile: .docgen/plugin.properties
+    exportedAs: Plugin
+configResolver: plugin


### PR DESCRIPTION
https://gravitee.atlassian.net/browse/APIM-13058

- Adds fallbackFile field to the bootstrap data struct, allowing bootstrap.yaml to declare an explicit fallback path when a primary data file is absent
- When plugin.properties is missing at the repo root (e.g. multi-module Maven repos), the loader transparently uses .docgen/plugin.properties instead 
- Non-breaking. Existing single-module repos are unaffected — the fallback path is only taken when the primary file is absent and fallbackFile is explicitly declared in bootstrap.yaml