### PR TITLE
feat: add generic multi-module documentation support

### DIFF
--- a/main.go
+++ b/main.go
@@ -25,6 +25,7 @@ import (
 	"github.com/gravitee-io/gravitee-doc-gen/pkg/core/generator"
 	"github.com/gravitee-io/gravitee-doc-gen/pkg/extenstions/bootstrap/examples"
 	"github.com/gravitee-io/gravitee-doc-gen/pkg/extenstions/bootstrap/filehandlers"
+	"github.com/gravitee-io/gravitee-doc-gen/pkg/extenstions/bootstrap/modules"
 	"github.com/gravitee-io/gravitee-doc-gen/pkg/extenstions/bootstrap/plugin"
 	"github.com/gravitee-io/gravitee-doc-gen/pkg/extenstions/bootstrap/scaffold"
 	"github.com/gravitee-io/gravitee-doc-gen/pkg/extenstions/generator/code"
@@ -60,6 +61,7 @@ func main() {
 
 	bootstrap.RegisterScaffolder("plugin", scaffold.PluginScaffolder)
 	bootstrap.RegisterPostProcessor("plugin", plugin.PostProcessor)
+	bootstrap.RegisterPostProcessor("modules", modules.PostProcessor)
 	bootstrap.RegisterPostProcessor("default-examples", examples.GenExamplePostProcessor)
 
 	config.RegisterConfigResolver("plugin", func(string, string) (string, error) {

--- a/pkg/core/bootstrap/load.go
+++ b/pkg/core/bootstrap/load.go
@@ -29,6 +29,7 @@ type data struct {
 	Filename     string `yaml:"file"`
 	FallbackFile string `yaml:"fallbackFile"`
 	ExportedAs   string `yaml:"exportedAs"`
+	Optional     bool   `yaml:"optional"`
 }
 
 type fileContent struct {
@@ -64,8 +65,15 @@ func Load(rootDir string) error {
 
 	for _, data := range bootstrap.Data {
 		file := data.Filename
-		if _, err := os.Stat(file); err != nil && data.FallbackFile != "" {
-			file = data.FallbackFile
+		if _, err := os.Stat(file); err != nil {
+			if data.FallbackFile != "" {
+				file = data.FallbackFile
+				if _, err := os.Stat(file); err != nil && data.Optional {
+					continue
+				}
+			} else if data.Optional {
+				continue
+			}
 		}
 		_, err := load(file, data.ExportedAs)
 		if err != nil {

--- a/pkg/core/config/types.go
+++ b/pkg/core/config/types.go
@@ -28,9 +28,10 @@ type Config struct {
 }
 
 type Output struct {
-	Template        string `yaml:"template"`
-	Target          string `yaml:"target"`
-	ProcessExisting bool   `yaml:"processExisting"`
+	Template        string            `yaml:"template"`
+	Target          string            `yaml:"target"`
+	ProcessExisting bool              `yaml:"processExisting"`
+	Vars            map[string]string `yaml:"vars"`
 }
 
 type Chunk struct {

--- a/pkg/core/output/yield.go
+++ b/pkg/core/output/yield.go
@@ -51,6 +51,10 @@ func Yield(output config.Output, generated []chunks.Generated, write bool) error
 	// make bootstrap data available
 	maps.Copy(data, bootstrap.GetExported())
 
+	if output.Vars != nil {
+		data["Vars"] = output.Vars
+	}
+
 	// render template
 	if rendered, err := util.RenderTemplateFromFile(output.Template, data); err == nil {
 		// add to buffer

--- a/pkg/extenstions/bootstrap/modules/modules.go
+++ b/pkg/extenstions/bootstrap/modules/modules.go
@@ -1,0 +1,59 @@
+// Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//         http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package modules
+
+import (
+	"fmt"
+
+	"github.com/gravitee-io/gravitee-doc-gen/pkg/core/util"
+)
+
+type Module struct {
+	ID         string `json:"id"`
+	Path       string `json:"path"`
+	Name       string `json:"name"`
+	ExportedAs string `json:"exportedAs"`
+}
+
+type modulesFile struct {
+	Modules []Module `json:"modules"`
+}
+
+func PostProcessor(data any) (any, error) {
+	raw := util.As[*util.Unstructured](data)
+	if raw == nil {
+		return nil, fmt.Errorf("modules data is nil")
+	}
+
+	mf, err := util.AnyMapToStruct[modulesFile](raw)
+	if err != nil {
+		return nil, fmt.Errorf("cannot parse modules data: %w", err)
+	}
+
+	if len(mf.Modules) == 0 {
+		return nil, fmt.Errorf("at least one module must be declared")
+	}
+
+	for i, m := range mf.Modules {
+		if m.Path == "" {
+			return nil, fmt.Errorf("module at index %d: path is required", i)
+		}
+		if m.ExportedAs == "" {
+			return nil, fmt.Errorf("module at index %d: exportedAs is required", i)
+		}
+	}
+
+	return mf.Modules, nil
+}

--- a/pkg/extenstions/common/examples/validation.go
+++ b/pkg/extenstions/common/examples/validation.go
@@ -33,15 +33,20 @@ func TypeValidator(chunk config.Chunk, provider ExampleSpecProvider) (bool, erro
 
 	examplesFile := chunks.GetString(chunk, "examples")
 	examplesFileExists := util.FileExists(examplesFile)
-
-	if chunk.Required && !examplesFileExists {
-		return examplesFileExists, errors.New(fmt.Sprintf("example file not found: %s", examplesFile))
+	if !examplesFileExists {
+		if chunk.Required {
+			return false, errors.New(fmt.Sprintf("example file not found: %s", examplesFile))
+		}
+		return false, nil
 	}
 
 	schemaFile := chunks.GetString(chunk, "schema")
 	schemaFileExists := util.FileExists(schemaFile)
-	if chunk.Required && !schemaFileExists {
-		return schemaFileExists, errors.New(fmt.Sprintf("schema file not found: %s", schemaFile))
+	if !schemaFileExists {
+		if chunk.Required {
+			return false, errors.New(fmt.Sprintf("schema file not found: %s", schemaFile))
+		}
+		return false, nil
 	}
 
 	err = LoadConfig(chunk, provider)

--- a/pkg/extenstions/generator/options/funcs.go
+++ b/pkg/extenstions/generator/options/funcs.go
@@ -37,8 +37,11 @@ func TypeValidator(chunk config.Chunk) (bool, error) {
 
 	schemaFile := chunks.GetString(chunk, "schema")
 	schemaFileExists := util.FileExists(schemaFile)
-	if chunk.Required && !schemaFileExists {
-		return false, errors.New("schema file not found")
+	if !schemaFileExists {
+		if chunk.Required {
+			return false, errors.New("schema file not found")
+		}
+		return false, nil
 	}
 
 	compiler := jsonschema.NewCompiler()


### PR DESCRIPTION
https://gravitee.atlassian.net/browse/APIM-13367

Goal: Make the tool capable of handling multi-module repos generically, without per-plugin hardcoding.

a) Output.Vars — parameterized output templates (config/types.go, output/yield.go)
Problem: Each output template was a fixed file. To generate 4 different POLICY_STUDIO_DOC.md files with different content, you needed 4 separate template files (like the old README_produce.tmpl, README_fetch.tmpl, etc.).

Fix: Added a Vars map[string]string field to the Output struct. When Vars is set, it's injected into the template context as .Vars. A single template can now be reused for all modules — the template reads .Vars.moduleName, .Vars.overviewChunk, etc. to dynamically look up the right chunk data.

b) Optional bootstrap data (bootstrap/load.go)
Problem: Bootstrap data sources in bootstrap.yaml were either mandatory or had a fallback. There was no way to say "this file might not exist, and that's fine."

Fix: Added an Optional bool field to the bootstrap data struct. When optional: true:

  - If the file doesn't exist on disk → silently skip (no error)
  - If both primary and fallback files are missing → skip gracefully
  - If the file exists but has parse errors → still error (a broken file is a bug, not an absent feature)
  - This is needed because modules.yaml only exists in multi-module repos. Single-module repos simply don't have it, and that's fine — the Modules key stays nil.

c) Modules post-processor (pkg/extenstions/bootstrap/modules/modules.go, main.go)
Problem: The raw YAML data from modules.yaml is loaded as an unstructured map[string]any. Templates need typed access to iterate over modules and read their fields.

Fix: Created a PostProcessor (same pattern as the existing plugin.PostProcessor) that:

  - Takes the raw unstructured data
  - Converts to typed Module structs using the existing util.AnyMapToStruct utility (reusing the codebase's own JSON roundtrip helper rather than re-implementing it)
  - Validates: at least one module declared, every module has path and exportedAs with index in error messages for debugging
  - Returns []Module which becomes .Modules in templates
  - Registered in main.go following the same bootstrap.RegisterPostProcessor pattern used by plugin and default-examples.

d) Graceful validation for non-required chunks (options/funcs.go, examples/validation.go)
Problem: The TypeValidator for options and examples chunks would try to compile the schema file even when the chunk was required: false and the file didn't exist. This crashed with "schema file not found".

In the old kafka-rules config, per-module options were required: false and this never triggered because target/classes/schemas/ always existed (post-compile). But with the new generic config, multi-module examples point to (index .Modules 0).Path/target/classes/... which may not exist if mvn compile wasn't run.

Fix: When required: false and the file is missing → return (false, nil) (skip gracefully). When required: true and the file is missing → still error loudly. When the file exists → proceed with normal compilation regardless of required flag.